### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kbruch.json
+++ b/org.kde.kbruch.json
@@ -11,6 +11,10 @@
         "--socket=fallback-x11",
         "--socket=wayland"
     ],
+     "cleanup": [
+        "/share/doc",
+        "/share/man"
+    ],
     "modules": [
         {
             "name": "kbruch",


### PR DESCRIPTION
The installed size reduced from 6.0 MB to 1.1 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.